### PR TITLE
fix check on error from bson_new_from_json

### DIFF
--- a/spec/bson_spec.cr
+++ b/spec/bson_spec.cr
@@ -335,4 +335,17 @@ describe BSON do
     fail "expected BSON" unless ary.is_a?(BSON)
     ary["0"].should eq(1)
   end
+
+  it "should decode json" do
+    s = "{ \"sval\" : \"1234\", \"ival\" : 1234 }"
+    bson = BSON.from_json s
+    bson.to_s.should eq s
+  end
+
+  it "should error json" do
+    s = "{ this = wrong }"
+    expect_raises do
+      bson = BSON.from_json s
+    end
+  end
 end

--- a/src/bson.cr
+++ b/src/bson.cr
@@ -23,7 +23,7 @@ class BSON
 
   def self.from_json(json)
     handle = LibBSON.bson_new_from_json(json, json.bytesize, out error)
-    if error
+    if error && error.message[0] != 0
       raise BSONError.new(pointerof(error))
     end
     new(handle)

--- a/src/bson.cr
+++ b/src/bson.cr
@@ -23,7 +23,7 @@ class BSON
 
   def self.from_json(json)
     handle = LibBSON.bson_new_from_json(json, json.bytesize, out error)
-    if error && error.message[0] != 0
+    if handle.null? && error
       raise BSONError.new(pointerof(error))
     end
     new(handle)


### PR DESCRIPTION
Existing check meant that every call was interpreted as an error, since error is always allocated as an out var.  I validated the fix with and without valid JSON:
```
bson = BSON.from_json "{\"a\" : 1}"
puts bson.to_s # { "a" : 1 }
bson = BSON.from_json "{ a = 6 }"
# Domain: 1, code: 1, Got parse error at 'a', position 2: SPECIAL_EXPECTED (BSON::BSONError)
```