### PR TITLE
find() for getting all document, without query

### DIFF
--- a/src/mongo/collection.cr
+++ b/src/mongo/collection.cr
@@ -128,8 +128,10 @@ class Mongo::Collection
   # must be placed inside of {"$query": {}} as specified by the server
   # documentation.
   # The results are passed to the specified block.
-  def find(query, fields = BSON.new, flags = LibMongoC::QueryFlags::NONE,
+  def find(query = nil, fields = BSON.new, flags = LibMongoC::QueryFlags::NONE,
            skip = 0, limit = 0, batch_size = 0, prefs = nil)
+    findall = {} of String => String
+    query = !query.nil? ? query : findall
     find(query, fields, flags, skip, limit, batch_size, prefs).each do |doc|
       yield doc
     end


### PR DESCRIPTION
hi, Find () always needs query when I dont need to use a query, I want to retrieve all Document

```
Error in myfile.cr:16: wrong number of arguments for 'Mongo::Collection#find' (given 0, expected 1..7)
Overloads are:
 - Mongo::Collection#find(query, fields = BSON.new, flags = LibMongoC::QueryFlags::NONE, skip = 0, limit = 0, batch_size = 0, prefs = nil)
 - Mongo::Collection#find(query, fields = BSON.new, flags = LibMongoC::QueryFlags::NONE, skip = 0, limit = 0, batch_size = 0, prefs = nil, &block)

pid.find() do |doc|
```