### PR TITLE
Support Crystal 0.24.1

### DIFF
--- a/spec/bson_spec.cr
+++ b/spec/bson_spec.cr
@@ -43,8 +43,8 @@ end
 describe BSON::Timestamp do
   it "should be comparable" do
     t = Time.now
-    t1 = BSON::Timestamp.new(t.ticks, 1)
-    t2 = BSON::Timestamp.new(t.ticks, 2)
+    t1 = BSON::Timestamp.new(t.epoch_ms, 1)
+    t2 = BSON::Timestamp.new(t.epoch_ms, 2)
     t2.should be > t1
   end
 end
@@ -145,7 +145,7 @@ describe BSON do
     bson.append_document("doc") do |child|
       child.not_nil!["body"] = "document body"
     end
-    expect_raises do
+    expect_raises(Exception) do
       child.not_nil!["v"] = 2
     end
   end
@@ -197,8 +197,8 @@ describe BSON do
   it "should be able to append timestamp" do
     t = Time.now
     bson = BSON.new
-    bson["ts"] = BSON::Timestamp.new(t.ticks, 1)
-    bson["ts"].should eq(BSON::Timestamp.new(t.ticks, 1))
+    bson["ts"] = BSON::Timestamp.new(t.epoch_ms, 1)
+    bson["ts"].should eq(BSON::Timestamp.new(t.epoch_ms, 1))
   end
 
   it "should be able to append regex" do
@@ -344,7 +344,7 @@ describe BSON do
 
   it "should error json" do
     s = "{ this = wrong }"
-    expect_raises do
+    expect_raises(Exception) do
       bson = BSON.from_json s
     end
   end

--- a/spec/uri_spec.cr
+++ b/spec/uri_spec.cr
@@ -33,7 +33,7 @@ describe Mongo::Uri do
   end
 
   it "should be able to parse auth_source and auth_mechanism" do
-    uri = Mongo::Uri.new "mongodb://christian:secret@localhost:27017?authMechanism=GSSAPI"
+    uri = Mongo::Uri.new "mongodb://christian:secret@domain.com:27017/?authMechanism=GSSAPI"
     uri.auth_mechanism.should eq("GSSAPI")
     uri.auth_source.should eq("$external")
     uri.username.should eq("christian")

--- a/spec/uri_spec.cr
+++ b/spec/uri_spec.cr
@@ -10,6 +10,14 @@ describe Mongo::Uri do
     host.port.should eq(27017)
   end
 
+  it "should work with various ports" do
+    uri = Mongo::Uri.new "mongodb://localhost:1443"
+    uri.hosts.size.should eq(1)
+    host = uri.hosts.first
+    host.host.should eq("localhost")
+    host.port.should eq(1443)
+  end
+
   it "should be able to create new uri with host and port" do
     uri = Mongo::Uri.new "localhost", 27017
     uri.hosts.size.should eq(1)

--- a/src/mongo/gridfs/file.cr
+++ b/src/mongo/gridfs/file.cr
@@ -1,5 +1,4 @@
-class Mongo::GridFS::File
-  include IO
+class Mongo::GridFS::File < IO
 
   property! timeout_msec
 
@@ -172,4 +171,3 @@ class Mongo::GridFS::File
     @handle
   end
 end
-

--- a/src/mongo/host.cr
+++ b/src/mongo/host.cr
@@ -15,6 +15,7 @@ class Mongo::Host
     cur = handle
     loop do
       break if cur.null?
+      puts "value: #{cur.value.port}"
       hosts << Host.new(String.new(cur.value.host.to_unsafe), cur.value.port, cur.value.family)
       cur = cur.value.next
       break if cur.null?
@@ -22,4 +23,3 @@ class Mongo::Host
     hosts
   end
 end
-

--- a/src/mongo/host.cr
+++ b/src/mongo/host.cr
@@ -15,7 +15,6 @@ class Mongo::Host
     cur = handle
     loop do
       break if cur.null?
-      puts "value: #{cur.value.port}"
       hosts << Host.new(String.new(cur.value.host.to_unsafe), cur.value.port, cur.value.family)
       cur = cur.value.next
       break if cur.null?


### PR DESCRIPTION
Updates syntax to support Crystal 0.24.1 breaking changes. On Ubuntu 17.10 I am still getting a few minor spec failures with respect to Port number parsing, however others are reporting all green, and since 17.10 is experimental I think we are good to merge). 

@datanoise 
@watzon 