### PR TITLE
changes to compile with crystal v24.1+

### DIFF
--- a/spec/bson_spec.cr
+++ b/spec/bson_spec.cr
@@ -40,11 +40,11 @@ describe BSON::ObjectId do
   end
 end
 
+
 describe BSON::Timestamp do
   it "should be comparable" do
-    t = Time.now
-    t1 = BSON::Timestamp.new(t.ticks, 1)
-    t2 = BSON::Timestamp.new(t.ticks, 2)
+    t1 = BSON::Timestamp.new(Time.now.epoch.to_u32, 0)
+    t2 = BSON::Timestamp.new(Time.now.epoch.to_u32, 1)
     t2.should be > t1
   end
 end
@@ -145,7 +145,7 @@ describe BSON do
     bson.append_document("doc") do |child|
       child.not_nil!["body"] = "document body"
     end
-    expect_raises do
+    expect_raises Exception do
       child.not_nil!["v"] = 2
     end
   end
@@ -197,8 +197,8 @@ describe BSON do
   it "should be able to append timestamp" do
     t = Time.now
     bson = BSON.new
-    bson["ts"] = BSON::Timestamp.new(t.ticks, 1)
-    bson["ts"].should eq(BSON::Timestamp.new(t.ticks, 1))
+    bson["ts"] = BSON::Timestamp.new(t.epoch.to_u32, 1)
+    bson["ts"].should eq(BSON::Timestamp.new(t.epoch.to_u32, 1))
   end
 
   it "should be able to append regex" do
@@ -344,7 +344,7 @@ describe BSON do
 
   it "should error json" do
     s = "{ this = wrong }"
-    expect_raises do
+    expect_raises Exception do
       bson = BSON.from_json s
     end
   end

--- a/spec/uri_spec.cr
+++ b/spec/uri_spec.cr
@@ -25,7 +25,7 @@ describe Mongo::Uri do
   end
 
   it "should be able to parse auth_source and auth_mechanism" do
-    uri = Mongo::Uri.new "mongodb://christian:secret@localhost:27017?authMechanism=GSSAPI"
+    uri = Mongo::Uri.new "mongodb://christian:secret@localhost:27017/?authMechanism=GSSAPI"
     uri.auth_mechanism.should eq("GSSAPI")
     uri.auth_source.should eq("$external")
     uri.username.should eq("christian")

--- a/src/bson/timestamp.cr
+++ b/src/bson/timestamp.cr
@@ -5,7 +5,9 @@ class BSON
     def initialize(@handle : LibBSON::Timestamp)
     end
 
-    def initialize(timestamp, increment)
+    # @param timestamp epoch seconds
+    # @param increment in seconds
+    def initialize(timestamp : UInt32, increment)
       handle = LibBSON::Timestamp.new
       handle.ts = timestamp.to_u32
       handle.incr = increment.to_u32

--- a/src/mongo/gridfs/file.cr
+++ b/src/mongo/gridfs/file.cr
@@ -1,5 +1,6 @@
-class Mongo::GridFS::File
-  include IO
+class Mongo::GridFS::File < IO
+  #include IO
+  # breaking change moved IO from module to class in release 0.24.1
 
   property! timeout_msec
 
@@ -172,4 +173,3 @@ class Mongo::GridFS::File
     @handle
   end
 end
-


### PR DESCRIPTION
While the GridFS specs pass, there might be something missing... I just removed the 'include IO' to get it compiling.

Crystal v24.1 had some breaking changes.
 - IO changed from module to class
 - Timestamp.ticks is gone