### PR TITLE
Update value.cr for crystal 0.25.0

### DIFF
--- a/src/bson/object_id.cr
+++ b/src/bson/object_id.cr
@@ -48,7 +48,7 @@ class BSON
       t = LibBSON.bson_oid_get_time_t(@handle)
       ts = LibC::Timespec.new
       ts.tv_sec = t
-      Time.new(ts, Time::Kind::Utc)
+      Time.new(ts, location: Time::Location::UTC)
     end
   end
 end

--- a/src/bson/timestamp.cr
+++ b/src/bson/timestamp.cr
@@ -14,6 +14,12 @@ class BSON
       initialize(handle)
     end
 
+    # @param timestamp epoch seconds
+    # @param increment in seconds
+    def initialize(timestamp : Int32 | Int64, increment)
+      initialize(timestamp.to_u32, increment)
+    end
+
     def timestamp
       @handle.ts
     end

--- a/src/bson/value.cr
+++ b/src/bson/value.cr
@@ -39,7 +39,7 @@ class BSON
       when LibBSON::Type::BSON_TYPE_DATE_TIME
         spec = LibC::Timespec.new
         spec.tv_sec = v.v_datetime / 1000
-        Time.new(spec, Time::Kind::Utc)
+        Time.new(spec, location: Time::Location::UTC)
       when LibBSON::Type::BSON_TYPE_NULL
         nil
       when LibBSON::Type::BSON_TYPE_REGEX

--- a/src/mongo/gridfs/file.cr
+++ b/src/mongo/gridfs/file.cr
@@ -89,7 +89,7 @@ class Mongo::GridFS::File < IO
     epoch = LibMongoC.gridfs_file_get_upload_date(self)
     spec = LibC::Timespec.new
     spec.tv_sec = epoch / 1000
-    Time.new(spec, Time::Kind::Utc)
+    Time.new(spec, location: Time::Location::UTC)
   end
 
   # Removes file and its data chunks from the MongoDB server.


### PR DESCRIPTION
https://crystal-lang.org/2018/06/15/crystal-0.25.0-released.html

Starting now Time has #location and #offset properties to know the timezone exactly. Time.now and Time.new will return by default information in the local timezone, while Time.utc_now and Time.utc will return information in UTC.