### PR TITLE
update to support crystal 0.25.1

### DIFF
--- a/src/bson/object_id.cr
+++ b/src/bson/object_id.cr
@@ -48,7 +48,7 @@ class BSON
       t = LibBSON.bson_oid_get_time_t(@handle)
       ts = LibC::Timespec.new
       ts.tv_sec = t
-      Time.new(ts, Time::Kind::Utc)
+      Time.new(ts, Time::Location::UTC)
     end
   end
 end

--- a/src/bson/timestamp.cr
+++ b/src/bson/timestamp.cr
@@ -7,7 +7,7 @@ class BSON
 
     # @param timestamp epoch seconds
     # @param increment in seconds
-    def initialize(timestamp : UInt32, increment)
+    def initialize(timestamp : Int, increment)
       handle = LibBSON::Timestamp.new
       handle.ts = timestamp.to_u32
       handle.incr = increment.to_u32

--- a/src/bson/value.cr
+++ b/src/bson/value.cr
@@ -39,7 +39,7 @@ class BSON
       when LibBSON::Type::BSON_TYPE_DATE_TIME
         spec = LibC::Timespec.new
         spec.tv_sec = v.v_datetime / 1000
-        Time.new(spec, Time::Kind::Utc)
+        Time.new(spec, Time::Location::UTC)
       when LibBSON::Type::BSON_TYPE_NULL
         nil
       when LibBSON::Type::BSON_TYPE_REGEX

--- a/src/mongo/gridfs/file.cr
+++ b/src/mongo/gridfs/file.cr
@@ -89,7 +89,7 @@ class Mongo::GridFS::File < IO
     epoch = LibMongoC.gridfs_file_get_upload_date(self)
     spec = LibC::Timespec.new
     spec.tv_sec = epoch / 1000
-    Time.new(spec, Time::Kind::Utc)
+    Time.new(spec, Time::Location::UTC)
   end
 
   # Removes file and its data chunks from the MongoDB server.


### PR DESCRIPTION
This is a WIP for crystal 0.25.1 support. I have successfully made the minor syntax changes that need to happen, however I am getting some double free memory errors during the bulk insertion spec when I run `crystal spec`. I have attempted to debug a bit with GDB however I have been unable to find what line is causing the double free as it is likely happening in the mongoc driver. Any assistance would be greatly appreciated.

```
Starting program: /usr/bin/crystal spec
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
[New Thread 0x7fffef015700 (LWP 23016)]
[New Thread 0x7fffee814700 (LWP 23017)]
[New Thread 0x7fffee013700 (LWP 23018)]
....................................................EEEEEEEEEEEEEEEEEE.EE..

Failures:

  1) Mongo::BulkOperation should be able to bulk insert documents

free(): invalid pointer
Program received and didn't handle signal IOT (6)
[Thread 0x7fffee013700 (LWP 23018) exited]
[Thread 0x7fffef015700 (LWP 23016) exited]
[Thread 0x7ffff7fb9780 (LWP 23015) exited]
[Inferior 1 (process 23015) exited with code 01]
```