### PR TITLE
:bug: Solved bulk method binding bug

### DIFF
--- a/src/mongo/bulk_operation.cr
+++ b/src/mongo/bulk_operation.cr
@@ -10,12 +10,14 @@ class Mongo::BulkOperation
 
   def finalize
     LibMongoC.bulk_operation_destroy(@handle)
+    self
   end
 
   # Queue an insert of a single document into a bulk operation. The insert is
   # not performed until `execute` is called.
   def insert(document)
     LibMongoC.bulk_operation_insert(self, document.to_bson)
+    self
   end
 
   # This method queues a delete operation as part of bulk that will delete
@@ -23,6 +25,7 @@ class Mongo::BulkOperation
   # `remove_one`.
   def remove(selector)
     LibMongoC.bulk_operation_remove(self, selector.to_bson)
+    self
   end
 
   # This method queues a delete operation as part of bulk that will delete a
@@ -30,12 +33,14 @@ class Mongo::BulkOperation
   # `remove`.
   def remove_one(selector)
     LibMongoC.bulk_operation_remove_one(self, selector.to_bson)
+    self
   end
 
   # Replace a single document as part of a bulk operation. This only queues the
   # operation. To execute it, call `execute`.
   def replace_one(selector, document, upsert = false)
     LibMongoC.bulk_operation_replace_one(self, selector.to_bson, document.to_bson, upsert)
+    self
   end
 
   # This method queues an update as part of a bulk operation. This does not
@@ -43,6 +48,7 @@ class Mongo::BulkOperation
   # `execute`.
   def update(selector, document, upsert = false)
     LibMongoC.bulk_operation_update(self, selector.to_bson, document.to_bson, upsert)
+    self
   end
 
   # This method queues an update as part of a bulk operation. It will only
@@ -51,6 +57,7 @@ class Mongo::BulkOperation
   # `execute`.
   def update_one(selector, document, upsert = false)
     LibMongoC.bulk_operation_update_one(self, selector.to_bson, document.to_bson, upsert)
+    self
   end
 
   # This method executes all operations queued into the bulk operation. If


### PR DESCRIPTION
There was a bug that prevented joining the methods of `bulk_operation` with the execution method` execute`