### PR TITLE
1.15 update

### DIFF
--- a/src/mongo.cr
+++ b/src/mongo.cr
@@ -38,4 +38,6 @@ module Mongo
   LibMongoC.log_set_handler ->(level, domain, msg, user_data) {
     self.log(level, String.new(domain), String.new(msg))
   }, nil
+  LibMongoC.mongo_init(nil)
+  at_exit { LibMongoC.mongo_cleanup(nil) }  
 end


### PR DESCRIPTION
needs to setup and call mongo init/cleanup to make 1.15 work
it ensures init and cleanup are called to mke the drivers work.