### PR TITLE
fixes collection_command_simple call and streams in pooled mode

### DIFF
--- a/src/mongo/collection.cr
+++ b/src/mongo/collection.cr
@@ -60,7 +60,7 @@ class Mongo::Collection
 
   # This is a simplified interface to command that returns the first result document.
   def command_simple(command, prefs = nil)
-    if LibMongoC.collection_command_simple(self, command.to_bson, out reply, out error)
+    if LibMongoC.collection_command_simple(self, command.to_bson, prefs, out reply, out error)
         repl = BSON.copy_from pointerof(reply)
         LibBSON.bson_destroy(pointerof(reply))
         repl


### PR DESCRIPTION
#### Issue

- collection_command_simple call

It seems that the `collection.cr` `command_simple` function calls the `LibMongoC.collection_command_simple` binding with a missing argument.

```
In lib/mongo/src/mongo/collection.cr:63:18

 63 | if LibMongoC.collection_command_simple(self, command.to_bson, out reply, out error)
                   ^------------------------
Error: wrong number of arguments for 'LibMongoC#collection_command_simple' (given 4, expected 5)
```

- streams in pooled mode

Custom streams using a `TCPSocket` were not connecting to the db properly when in pooled mode, since polling is dedicated to a background thread unlike in single thread mode.

#### Done

- Added the mongo preferences `prefs` as a third argument to satisfy the call.
- Fixes socket connection when in pooled mode by adding a connected bool as a class variable and forcing connection when requesting the socket and connected is false.