### PR TITLE
bson: fix memory leaks when appending documents or arrays

### DIFF
--- a/src/bson.cr
+++ b/src/bson.cr
@@ -211,28 +211,22 @@ class BSON
 
   def append_document(key)
     child_handle = LibBSON.bson_new()
-    unless LibBSON.bson_append_document_begin(handle, key, key.bytesize, child_handle)
-      return false
-    end
     child = BSON.new(child_handle)
     begin
       yield child
+      LibBSON.bson_append_document(handle, key, key.bytesize, child_handle)
     ensure
-      LibBSON.bson_append_document_end(handle, child)
       child.invalidate
     end
   end
 
   def append_array(key)
     child_handle = LibBSON.bson_new()
-    unless LibBSON.bson_append_array_begin(handle, key, key.bytesize, child_handle)
-      return false
-    end
     child = BSON.new(child_handle)
     begin
       yield ArrayAppender.new(child), child
+      LibBSON.bson_append_array(handle, key, key.bytesize, child_handle)
     ensure
-      LibBSON.bson_append_array_end(handle, child)
       child.invalidate
     end
   end

--- a/src/bson/lib_bson.cr
+++ b/src/bson/lib_bson.cr
@@ -70,7 +70,7 @@ lib LibBSON
      MONGOC_ERROR_SERVER,
      MONGOC_ERROR_TRANSACTION,
   end
-	
+
   enum ErrorCode
      MONGOC_ERROR_STREAM_INVALID_TYPE = 1,
      MONGOC_ERROR_STREAM_INVALID_STATE,
@@ -253,6 +253,7 @@ lib LibBSON
   fun bson_append_document = bson_append_document(bson: BSON, key: UInt8*, key_length: Int32, value: BSON) : Bool
   fun bson_append_array_begin = bson_append_array_begin(bson: BSON, key: UInt8*, key_length: Int32, child: BSON) : Bool
   fun bson_append_array_end = bson_append_array_end(bson: BSON, child: BSON) : Bool
+  fun bson_append_array = bson_append_array(bson: BSON, key: UInt8*, key_length: Int32, child: BSON) : Bool
   fun bson_append_symbol = bson_append_symbol(bson: BSON, key: UInt8*, key_length: Int32, value: UInt8*, length: Int32) : Bool
   fun bson_append_date_time = bson_append_date_time(bson: BSON, key: UInt8*, key_length: Int32, value: Int64) : Bool
   fun bson_append_timestamp = bson_append_timestamp(bson: BSON, key: UInt8*, key_length: Int32, ts: UInt32, incr: UInt32) : Bool


### PR DESCRIPTION
#### Issue

Calling `append_document` or `append_array` was leaking memory as`LibBSON.bson_append_document_begin` or `LibBSON.bson_append_array_begin` are not supposed to be called with an already allocated bson handler.

#### Fix

Replaced `bson_append_document_begin` + `bson_append_document_end` combo with a single `bson_append_document` call. Same fix for arrays.

